### PR TITLE
PHP 8.x: Trying to access array offset on value of type null

### DIFF
--- a/semantic_fields.module
+++ b/semantic_fields.module
@@ -31,6 +31,9 @@ function semantic_fields_form_alter(&$form, &$form_state, $form_id) {
 
     foreach (element_children($form['fields']) as $name) {
       $instance = field_info_instance($entity_type, $name, $bundle);
+      if (!$instance) {
+        continue;
+      }
       $display = $instance['display'][$view_mode];
       $settings = (isset($form_state['formatter_settings'][$name]) ? $form_state['formatter_settings'][$name] : $display['settings']);
 


### PR DESCRIPTION
Fixes #1

This fixes a PHP 8.x warning we were seeing on semantic field display management pages like /admin/config/people/manage/display/default, Trying to access array offset on value of type null in semantic_fields_form_alter().